### PR TITLE
Fix Rust support

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -59,7 +59,7 @@
         <annotator language="Python" implementationClass="com.github.izhangzhihao.rainbow.brackets.RainbowBrackets"/>
         <annotator language="Haskell" implementationClass="com.github.izhangzhihao.rainbow.brackets.RainbowBrackets"/>
         <annotator language="Agda" implementationClass="com.github.izhangzhihao.rainbow.brackets.RainbowBrackets"/>
-        <annotator language="RUST" implementationClass="com.github.izhangzhihao.rainbow.brackets.RainbowBrackets"/>
+        <annotator language="Rust" implementationClass="com.github.izhangzhihao.rainbow.brackets.RainbowBrackets"/>
         <annotator language="JavaScript"
                    implementationClass="com.github.izhangzhihao.rainbow.brackets.RainbowBrackets"/>
         <annotator language="Erlang" implementationClass="com.github.izhangzhihao.rainbow.brackets.RainbowBrackets"/>


### PR DESCRIPTION
This is tiny fix for language value for rust (with respect to https://github.com/intellij-rust/intellij-rust/blob/master/src/main/resources/META-INF/plugin.xml#L49).  Brackets actually work in rust now:

![fh6ls6b](https://user-images.githubusercontent.com/25141408/32992148-002269cc-cd50-11e7-950f-8d3c940470b0.png)