### PR TITLE
Add setting to disable rainbow-ify brackets without content

### DIFF
--- a/src/main/java/com/github/izhangzhihao/rainbow/brackets/settings/RainbowSettingsForm.form
+++ b/src/main/java/com/github/izhangzhihao/rainbow/brackets/settings/RainbowSettingsForm.form
@@ -8,7 +8,7 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="fd26e" binding="appearancePanel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="fd26e" binding="appearancePanel" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -24,11 +24,6 @@
               <text value="Enable rainbow brackets"/>
             </properties>
           </component>
-          <hspacer id="49e34">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </hspacer>
           <component id="f915" class="javax.swing.JCheckBox" binding="enableRainbowRoundBrackets" default-binding="true">
             <constraints>
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -81,6 +76,14 @@
               <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
+          <component id="51ef4" class="javax.swing.JCheckBox" binding="doNOTRainbowifyBracketsWithoutContent">
+            <constraints>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Do NOT rainbow-ify brackets without content"/>
+            </properties>
+          </component>
         </children>
       </grid>
       <vspacer id="9e387">

--- a/src/main/java/com/github/izhangzhihao/rainbow/brackets/settings/RainbowSettingsForm.java
+++ b/src/main/java/com/github/izhangzhihao/rainbow/brackets/settings/RainbowSettingsForm.java
@@ -10,6 +10,7 @@ public class RainbowSettingsForm {
     private JCheckBox enableRainbowSquigglyBrackets;
     private JCheckBox enableRainbowSquareBrackets;
     private JCheckBox enableRainbowAngleBrackets;
+    private JCheckBox doNOTRainbowifyBracketsWithoutContent;
 
     private final RainbowSettings settings;
 
@@ -20,6 +21,7 @@ public class RainbowSettingsForm {
         enableRainbowSquigglyBrackets.setSelected(settings.isEnableRainbowSquigglyBrackets());
         enableRainbowSquareBrackets.setSelected(settings.isEnableRainbowSquareBrackets());
         enableRainbowAngleBrackets.setSelected(settings.isEnableRainbowAngleBrackets());
+        doNOTRainbowifyBracketsWithoutContent.setSelected(settings.isDoNOTRainbowifyBracketsWithoutContent());
     }
 
     public JComponent getComponent() {
@@ -46,12 +48,17 @@ public class RainbowSettingsForm {
         return enableRainbowAngleBrackets.isSelected();
     }
 
+    public boolean isDoNOTRainbowifyBracketsWithoutContent() {
+        return doNOTRainbowifyBracketsWithoutContent.isSelected();
+    }
+
     public boolean isModified() {
         return isRainbowEnabled() != settings.isRainbowEnabled()
                 || isRainbowAngleBracketsEnabled() != settings.isEnableRainbowAngleBrackets()
                 || isRainbowRoundBracketsEnabled() != settings.isEnableRainbowRoundBrackets()
                 || isRainbowSquigglyBracketsEnabled() != settings.isEnableRainbowSquigglyBrackets()
-                || isRainbowSquareBracketsEnabled() != settings.isEnableRainbowSquareBrackets();
+                || isRainbowSquareBracketsEnabled() != settings.isEnableRainbowSquareBrackets()
+                || isDoNOTRainbowifyBracketsWithoutContent() != settings.isDoNOTRainbowifyBracketsWithoutContent();
     }
 
     public void reset() {
@@ -60,5 +67,6 @@ public class RainbowSettingsForm {
         enableRainbowAngleBrackets.setSelected(settings.isEnableRainbowAngleBrackets());
         enableRainbowSquigglyBrackets.setSelected(settings.isEnableRainbowSquigglyBrackets());
         enableRainbowSquareBrackets.setSelected(settings.isEnableRainbowSquareBrackets());
+        doNOTRainbowifyBracketsWithoutContent.setSelected(settings.isDoNOTRainbowifyBracketsWithoutContent());
     }
 }

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/RainbowHighlighter.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/RainbowHighlighter.kt
@@ -47,6 +47,7 @@ object RainbowHighlighter {
     val isEnableRainbowSquigglyBrackets get() = settings.isEnableRainbowSquigglyBrackets
     val isEnableRainbowSquareBrackets get() = settings.isEnableRainbowSquareBrackets
     val isEnableRainbowAngleBrackets get() = settings.isEnableRainbowAngleBrackets
+    val isDoNOTRainbowifyBracketsWithoutContent get() = settings.isDoNOTRainbowifyBracketsWithoutContent
 
     private val rainbowElement: HighlightInfoType = HighlightInfoType
             .HighlightInfoTypeImpl(HighlightSeverity.INFORMATION, DefaultLanguageHighlighterColors.CONSTANT)

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowConfigurable.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowConfigurable.kt
@@ -25,6 +25,7 @@ class RainbowConfigurable : Configurable {
         settings.isEnableRainbowAngleBrackets = settingsForm?.isRainbowAngleBracketsEnabled ?: true
         settings.isEnableRainbowSquigglyBrackets = settingsForm?.isRainbowSquigglyBracketsEnabled ?: true
         settings.isEnableRainbowSquareBrackets = settingsForm?.isRainbowSquareBracketsEnabled ?: true
+        settings.isDoNOTRainbowifyBracketsWithoutContent = settingsForm?.isDoNOTRainbowifyBracketsWithoutContent ?: false
     }
 
     override fun reset() {

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowSettings.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowSettings.kt
@@ -18,6 +18,7 @@ class RainbowSettings : PersistentStateComponent<RainbowSettings> {
     var isEnableRainbowSquigglyBrackets = true
     var isEnableRainbowSquareBrackets = true
     var isEnableRainbowAngleBrackets = true
+    var isDoNOTRainbowifyBracketsWithoutContent = false
 
     @Nullable
     override fun getState() = this


### PR DESCRIPTION
Setting page:
<img width="370" alt="screen shot 2018-03-11 at 11 23 42 pm" src="https://user-images.githubusercontent.com/12044174/37255261-bba20036-2584-11e8-944f-a8161e248e7e.png">
Default:
<img width="275" alt="screen shot 2018-03-11 at 11 23 33 pm" src="https://user-images.githubusercontent.com/12044174/37255266-c6d7107c-2584-11e8-89c5-ba3c8ba2b2e6.png">
After disable rainbow-ify brackets without content:
<img width="260" alt="screen shot 2018-03-11 at 11 23 16 pm" src="https://user-images.githubusercontent.com/12044174/37255268-cc120114-2584-11e8-8c26-28ae2ac15ecc.png">
