### PR TITLE
[Feature #37] Highlight current scope when Ctrl/Meta(Mac) key pressed

### DIFF
--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import java.awt.Color
 import java.awt.Font
@@ -105,17 +106,16 @@ class CtrlHandler : EditorEventListener {
 
         private fun PsiFile.findRainbowInfoAt(offset: Int): RainbowInfo? {
             var element = findElementAt(offset)
-            var rainbowInfo: RainbowInfo? = null
             while (element != null) {
-                rainbowInfo = RainbowInfo.KEY_RAINBOW[element]
-                if (rainbowInfo != null && rainbowInfo.isValid()) {
-                    break
-                }
-
+                element.getRainbowInfo(offset)?.let { return it }
                 element = element.parent
             }
 
-            return rainbowInfo
+            return null
+        }
+
+        private fun PsiElement.getRainbowInfo(offset: Int): RainbowInfo? {
+            return RainbowInfo.KEY_RAINBOW[this]?.takeIf { it.containsOffset(offset) }
         }
 
         private fun Color.alphaBlend(background: Color, alpha: Float): Color {

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.editor.markup.EffectType
 import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 import java.awt.Color
@@ -32,7 +33,7 @@ class CtrlHandler : EditorEventListener {
             return
         }
 
-        if (keyEvent.keyCode != KeyEvent.VK_CONTROL || !keyEvent.isControlDown) {
+        if (!keyEvent.isControlOrMetaKey) {
             editor.removeHighlighter()
             return
         }
@@ -48,6 +49,13 @@ class CtrlHandler : EditorEventListener {
             highlighting = editor.addHighlightAt(caretOffset)
         }
     }
+
+    private val KeyEvent.isControlOrMetaKey: Boolean
+        get() = if (SystemInfo.isMac) {
+            isMetaDown && keyCode == KeyEvent.VK_META
+        } else {
+            isControlDown && keyCode == KeyEvent.VK_CONTROL
+        }
 
     override fun onKeyReleased(editor: Editor, keyEvent: KeyEvent) {
         editor.removeHighlighter()

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
@@ -2,12 +2,14 @@ package com.github.izhangzhihao.rainbow.brackets
 
 import com.intellij.codeInsight.highlighting.HighlightManager
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.markup.EffectType
 import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
+import java.awt.Color
 import java.awt.Font
 import java.awt.event.FocusEvent
 import java.awt.event.KeyEvent
@@ -53,9 +55,11 @@ class CtrlHandler : EditorEventListener {
         val psiFile = project.let { PsiDocumentManager.getInstance(it).getPsiFile(document) } ?: return false
         val rainbowInfo = psiFile.findRainbowInfoAt(offset) ?: return false
 
-        val highlighters = ArrayList<RangeHighlighter>()
-        val attributes = TextAttributes(null, null, rainbowInfo.color, EffectType.BOXED, Font.PLAIN)
+        val defaultBackground = EditorColorsManager.getInstance().globalScheme.defaultBackground
+        val background = rainbowInfo.color.alphaBlend(defaultBackground, 0.3f)
+        val attributes = TextAttributes(null, background, rainbowInfo.color, EffectType.BOXED, Font.PLAIN)
         val highlightManager = HighlightManager.getInstance(project)
+        val highlighters = ArrayList<RangeHighlighter>()
 
         highlightManager.addRangeHighlight(
                 this,
@@ -97,6 +101,14 @@ class CtrlHandler : EditorEventListener {
             }
 
             return rainbowInfo
+        }
+
+        private fun Color.alphaBlend(background: Color, alpha: Float): Color {
+            val r = (1 - alpha) * background.red + alpha * red
+            val g = (1 - alpha) * background.green + alpha * green
+            val b = (1 - alpha) * background.blue + alpha * blue
+
+            return Color(r.toInt(), g.toInt(), b.toInt())
         }
     }
 }

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
@@ -1,0 +1,102 @@
+package com.github.izhangzhihao.rainbow.brackets
+
+import com.intellij.codeInsight.highlighting.HighlightManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.markup.EffectType
+import com.intellij.openapi.editor.markup.RangeHighlighter
+import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+import java.awt.Font
+import java.awt.event.FocusEvent
+import java.awt.event.KeyEvent
+
+/**
+ * CtrlHandler
+ *
+ * Created by Yii.Guxing on 2018/05/13
+ */
+class CtrlHandler : EditorEventListener {
+
+    private var highlighting = false
+    private var storedCaretOffset = -1
+
+    override fun onKeyPressed(editor: Editor, keyEvent: KeyEvent) {
+        if (keyEvent.keyCode != KeyEvent.VK_CONTROL || !keyEvent.isControlDown) {
+            editor.removeHighlighter()
+            return
+        }
+
+        val caretOffset = editor.caretModel.offset
+        if (caretOffset == storedCaretOffset) {
+            return
+        }
+
+        editor.removeHighlighter()
+        storedCaretOffset = caretOffset
+        if (!highlighting) {
+            highlighting = editor.addHighlightAt(caretOffset)
+        }
+    }
+
+    override fun onKeyReleased(editor: Editor, keyEvent: KeyEvent) {
+        editor.removeHighlighter()
+    }
+
+    override fun onFocusLost(editor: Editor, focusEvent: FocusEvent) {
+        editor.removeHighlighter()
+    }
+
+    private fun Editor.addHighlightAt(offset: Int): Boolean {
+        val project = project ?: return false
+        val psiFile = project.let { PsiDocumentManager.getInstance(it).getPsiFile(document) } ?: return false
+        val rainbowInfo = psiFile.findRainbowInfoAt(offset) ?: return false
+
+        val highlighters = ArrayList<RangeHighlighter>()
+        val attributes = TextAttributes(null, null, rainbowInfo.color, EffectType.BOXED, Font.PLAIN)
+        val highlightManager = HighlightManager.getInstance(project)
+
+        highlightManager.addRangeHighlight(
+                this,
+                rainbowInfo.startOffset,
+                rainbowInfo.endOffset,
+                attributes,
+                true,
+                true,
+                highlighters)
+
+        KEY_REMOVE_HIGHLIGHTER_ACTION[this] = {
+            highlighters.forEach { highlightManager.removeSegmentHighlighter(this, it) }
+        }
+
+        return true
+    }
+
+    private fun Editor.removeHighlighter() {
+        storedCaretOffset = -1
+        if (highlighting) {
+            KEY_REMOVE_HIGHLIGHTER_ACTION[this]?.invoke()
+            highlighting = false
+        }
+    }
+
+    companion object {
+        private val KEY_REMOVE_HIGHLIGHTER_ACTION: Key<() -> Unit> = Key.create("REMOVE_HIGHLIGHTER_ACTION")
+
+        private fun PsiFile.findRainbowInfoAt(offset: Int): RainbowInfo? {
+            var element = findElementAt(offset)
+            var rainbowInfo: RainbowInfo? = null
+            while (element != null) {
+                rainbowInfo = RainbowInfo.KEY_RAINBOW[element]
+                if (rainbowInfo != null && rainbowInfo.isValid()) {
+                    break
+                }
+
+                element = element.parent
+            }
+
+            return rainbowInfo
+        }
+    }
+}

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
@@ -56,7 +56,7 @@ class CtrlHandler : EditorEventListener {
         val rainbowInfo = psiFile.findRainbowInfoAt(offset) ?: return false
 
         val defaultBackground = EditorColorsManager.getInstance().globalScheme.defaultBackground
-        val background = rainbowInfo.color.alphaBlend(defaultBackground, 0.3f)
+        val background = rainbowInfo.color.alphaBlend(defaultBackground, 0.2f)
         val attributes = TextAttributes(null, background, rainbowInfo.color, EffectType.BOXED, Font.PLAIN)
         val highlightManager = HighlightManager.getInstance(project)
         val highlighters = ArrayList<RangeHighlighter>()

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
@@ -88,6 +88,7 @@ class CtrlHandler : EditorEventListener {
         storedCaretOffset = -1
         if (highlighting) {
             KEY_REMOVE_HIGHLIGHTER_ACTION[this]?.invoke()
+            putUserData(KEY_REMOVE_HIGHLIGHTER_ACTION, null)
             highlighting = false
         }
     }

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
@@ -1,5 +1,6 @@
 package com.github.izhangzhihao.rainbow.brackets
 
+import com.github.izhangzhihao.rainbow.brackets.settings.RainbowSettings
 import com.intellij.codeInsight.highlighting.HighlightManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.EditorColorsManager
@@ -21,10 +22,16 @@ import java.awt.event.KeyEvent
  */
 class CtrlHandler : EditorEventListener {
 
+    private var settings = RainbowSettings.instance
+
     private var highlighting = false
     private var storedCaretOffset = -1
 
     override fun onKeyPressed(editor: Editor, keyEvent: KeyEvent) {
+        if (!settings.isEnableHighlightCurrentScopeWhenCtrlPressed) {
+            return
+        }
+
         if (keyEvent.keyCode != KeyEvent.VK_CONTROL || !keyEvent.isControlDown) {
             editor.removeHighlighter()
             return

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/CtrlHandler.kt
@@ -50,13 +50,6 @@ class CtrlHandler : EditorEventListener {
         }
     }
 
-    private val KeyEvent.isControlOrMetaKey: Boolean
-        get() = if (SystemInfo.isMac) {
-            isMetaDown && keyCode == KeyEvent.VK_META
-        } else {
-            isControlDown && keyCode == KeyEvent.VK_CONTROL
-        }
-
     override fun onKeyReleased(editor: Editor, keyEvent: KeyEvent) {
         editor.removeHighlighter()
     }
@@ -76,8 +69,7 @@ class CtrlHandler : EditorEventListener {
         val highlightManager = HighlightManager.getInstance(project)
         val highlighters = ArrayList<RangeHighlighter>()
 
-        highlightManager.addRangeHighlight(
-                this,
+        highlightManager.addRangeHighlight(this,
                 rainbowInfo.startOffset,
                 rainbowInfo.endOffset,
                 attributes,
@@ -103,6 +95,13 @@ class CtrlHandler : EditorEventListener {
 
     companion object {
         private val KEY_REMOVE_HIGHLIGHTER_ACTION: Key<() -> Unit> = Key.create("REMOVE_HIGHLIGHTER_ACTION")
+
+        private val KeyEvent.isControlOrMetaKey: Boolean
+            get() = if (SystemInfo.isMac) {
+                isMetaDown && keyCode == KeyEvent.VK_META
+            } else {
+                isControlDown && keyCode == KeyEvent.VK_CONTROL
+            }
 
         private fun PsiFile.findRainbowInfoAt(offset: Int): RainbowInfo? {
             var element = findElementAt(offset)

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/EditorEventActionManager.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/EditorEventActionManager.kt
@@ -1,0 +1,98 @@
+@file:Suppress("unused")
+
+package com.github.izhangzhihao.rainbow.brackets
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.event.EditorFactoryAdapter
+import com.intellij.openapi.editor.event.EditorFactoryEvent
+import com.intellij.openapi.util.Disposer
+import java.awt.event.FocusEvent
+import java.awt.event.FocusListener
+import java.awt.event.KeyEvent
+import java.awt.event.KeyListener
+
+class EditorEventActionManager : Disposable {
+
+    private val executeOnEditorRelease = HashMap<Editor, () -> Unit>()
+    private val listeners = ArrayList<EditorEventListener>()
+
+    fun registerEditorEventListener(listener: EditorEventListener) {
+        listeners.add(listener)
+    }
+
+    fun unregisterEditorEventListener(listener: EditorEventListener) {
+        listeners.remove(listener)
+    }
+
+    fun install() {
+        EditorFactory.getInstance().addEditorFactoryListener(object : EditorFactoryAdapter() {
+            override fun editorCreated(event: EditorFactoryEvent) {
+                val editor = event.editor
+                val eventListener = EventListener(editor)
+                val contentComponent = editor.contentComponent
+
+                contentComponent.addKeyListener(eventListener)
+                contentComponent.addFocusListener(eventListener)
+                executeOnEditorRelease[editor] = {
+                    contentComponent.removeKeyListener(eventListener)
+                    contentComponent.removeFocusListener(eventListener)
+                }
+            }
+
+            override fun editorReleased(event: EditorFactoryEvent) {
+                executeOnEditorRelease.remove(event.editor)?.invoke()
+            }
+        }, this)
+    }
+
+    fun uninstall() {
+        Disposer.dispose(this)
+    }
+
+    override fun dispose() {
+        listeners.clear()
+        executeOnEditorRelease.apply {
+            forEach { _, action -> action() }
+            clear()
+        }
+    }
+
+    private inner class EventListener(private val editor: Editor) : KeyListener, FocusListener {
+
+        override fun keyTyped(e: KeyEvent) {
+            runEditorEventAction(e, EditorEventListener::onKeyTyped)
+        }
+
+        override fun keyPressed(e: KeyEvent) {
+            runEditorEventAction(e, EditorEventListener::onKeyPressed)
+        }
+
+        override fun keyReleased(e: KeyEvent) {
+            runEditorEventAction(e, EditorEventListener::onKeyReleased)
+        }
+
+        override fun focusGained(e: FocusEvent) {
+            runEditorEventAction(e, EditorEventListener::onFocusGained)
+        }
+
+        override fun focusLost(e: FocusEvent) {
+            runEditorEventAction(e, EditorEventListener::onFocusLost)
+        }
+
+        private inline fun <reified E> runEditorEventAction(
+                e: E, action: EditorEventListener.(Editor, E) -> Unit) {
+            val editor = editor
+            if (!editor.isDisposed) {
+                listeners.forEach { it.action(editor, e) }
+            }
+        }
+    }
+
+    companion object {
+        val instance: EditorEventActionManager
+            get() = ServiceManager.getService(EditorEventActionManager::class.java)
+    }
+}

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/EditorEventListener.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/EditorEventListener.kt
@@ -28,12 +28,12 @@ interface EditorEventListener : EventListener {
     fun onKeyReleased(editor: Editor, keyEvent: KeyEvent) {}
 
     /**
-     * Invoked when a [Editor] gains the keyboard focus.
+     * Invoked when an [Editor] gains the keyboard focus.
      */
     fun onFocusGained(editor: Editor, focusEvent: FocusEvent) {}
 
     /**
-     * Invoked when a [Editor] loses the keyboard focus.
+     * Invoked when an [Editor] loses the keyboard focus.
      */
     fun onFocusLost(editor: Editor, focusEvent: FocusEvent) {}
 

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/EditorEventListener.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/EditorEventListener.kt
@@ -1,0 +1,40 @@
+package com.github.izhangzhihao.rainbow.brackets
+
+import com.intellij.openapi.editor.Editor
+import java.awt.event.FocusEvent
+import java.awt.event.KeyEvent
+import java.util.*
+
+/**
+ * EditorEventListener
+ *
+ * Created by Yii.Guxing on 2018/05/13
+ */
+interface EditorEventListener : EventListener {
+
+    /**
+     * Invoked when a key has been typed.
+     */
+    fun onKeyTyped(editor: Editor, keyEvent: KeyEvent) {}
+
+    /**
+     * Invoked when a key has been pressed.
+     */
+    fun onKeyPressed(editor: Editor, keyEvent: KeyEvent) {}
+
+    /**
+     * Invoked when a key has been released.
+     */
+    fun onKeyReleased(editor: Editor, keyEvent: KeyEvent) {}
+
+    /**
+     * Invoked when a [Editor] gains the keyboard focus.
+     */
+    fun onFocusGained(editor: Editor, focusEvent: FocusEvent) {}
+
+    /**
+     * Invoked when a [Editor] loses the keyboard focus.
+     */
+    fun onFocusLost(editor: Editor, focusEvent: FocusEvent) {}
+
+}

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/RainbowInfo.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/RainbowInfo.kt
@@ -1,0 +1,18 @@
+package com.github.izhangzhihao.rainbow.brackets
+
+import com.intellij.openapi.util.Key
+import java.awt.Color
+
+/**
+ * RainbowInfo
+ *
+ * Created by Yii.Guxing on 2018/05/12
+ */
+data class RainbowInfo(var level: Int, var color: Color, var startOffset: Int = -1, var endOffset: Int = -1) {
+
+    fun isValid(): Boolean = startOffset in 0..(endOffset - 1)
+
+    companion object {
+        val KEY_RAINBOW: Key<RainbowInfo> = Key.create("RAINBOW_INFO")
+    }
+}

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/RainbowInfo.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/RainbowInfo.kt
@@ -32,13 +32,13 @@ data class RainbowInfo(var level: Int, var color: Color) {
 
     val endOffset get() = endElement?.endOffset ?: -1
 
-    fun isValid(): Boolean {
+    fun containsOffset(offset: Int): Boolean {
         val startElement = startElement ?: return false
         val endElement = endElement ?: return false
         val startOffset = startElement.startOffset
         val endOffset = endElement.endOffset
 
-        return startOffset in 0..(endOffset - 1)
+        return offset in startOffset..endOffset
     }
 
     companion object {

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/RainbowInfo.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/RainbowInfo.kt
@@ -1,16 +1,45 @@
 package com.github.izhangzhihao.rainbow.brackets
 
 import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import java.awt.Color
+import java.lang.ref.WeakReference
 
 /**
  * RainbowInfo
  *
  * Created by Yii.Guxing on 2018/05/12
  */
-data class RainbowInfo(var level: Int, var color: Color, var startOffset: Int = -1, var endOffset: Int = -1) {
+data class RainbowInfo(var level: Int, var color: Color) {
+    private var _startElement: WeakReference<PsiElement>? = null
+    private var _endElement: WeakReference<PsiElement>? = null
 
-    fun isValid(): Boolean = startOffset in 0..(endOffset - 1)
+    var startElement: PsiElement?
+        get() = _startElement?.get()
+        set(value) {
+            _startElement = value?.let { WeakReference(it) }
+        }
+
+    val startOffset get() = startElement?.startOffset ?: -1
+
+    var endElement: PsiElement?
+        get() = _endElement?.get()
+        set(value) {
+            _endElement = value?.let { WeakReference(it) }
+        }
+
+    val endOffset get() = endElement?.endOffset ?: -1
+
+    fun isValid(): Boolean {
+        val startElement = startElement ?: return false
+        val endElement = endElement ?: return false
+        val startOffset = startElement.startOffset
+        val endOffset = endElement.endOffset
+
+        return startOffset in 0..(endOffset - 1)
+    }
 
     companion object {
         val KEY_RAINBOW: Key<RainbowInfo> = Key.create("RAINBOW_INFO")

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/component/RainbowComponent.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/component/RainbowComponent.kt
@@ -1,5 +1,7 @@
 package com.github.izhangzhihao.rainbow.brackets.component
 
+import com.github.izhangzhihao.rainbow.brackets.CtrlHandler
+import com.github.izhangzhihao.rainbow.brackets.EditorEventActionManager
 import com.github.izhangzhihao.rainbow.brackets.settings.RainbowSettings
 import com.intellij.ide.plugins.IdeaPluginDescriptor
 import com.intellij.ide.plugins.PluginManager
@@ -14,20 +16,34 @@ class RainbowComponent : ApplicationComponent {
     var updated: Boolean = false
 
     override fun initComponent() {
+        EditorEventActionManager.instance.apply {
+            registerEditorEventListener(CtrlHandler())
+            install()
+        }
+
         updated = getPlugin()?.version != RainbowSettings.instance.version
         if (updated) {
             RainbowSettings.instance.version = getPlugin()?.version
         }
         if (!RainbowSettings.instance.isRainbowifyHTMLInsideJS) {
-            EditorColorsManager.getInstance().globalScheme.setAttributes(createTextAttributesKey("HTML_CODE"), TextAttributes())
+            EditorColorsManager
+                    .getInstance()
+                    .globalScheme
+                    .setAttributes(createTextAttributesKey("HTML_CODE"), TextAttributes())
             RainbowSettings.instance.isRainbowifyHTMLInsideJS = true
         }
+    }
+
+    override fun disposeComponent() {
+        EditorEventActionManager.instance.uninstall()
+        super.disposeComponent()
     }
 
     companion object {
         val instance: RainbowComponent
             get() = ApplicationManager.getApplication().getComponent(RainbowComponent::class.java)
 
-        private fun getPlugin(): IdeaPluginDescriptor? = PluginManager.getPlugin(PluginId.getId("izhangzhihao.rainbow.brackets"))
+        private fun getPlugin(): IdeaPluginDescriptor? = PluginManager.getPlugin(
+                PluginId.getId("izhangzhihao.rainbow.brackets"))
     }
 }

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowConfigurable.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowConfigurable.kt
@@ -26,6 +26,7 @@ class RainbowConfigurable : Configurable {
         settings.isEnableRainbowAngleBrackets = settingsForm?.isRainbowAngleBracketsEnabled() ?: true
         settings.isEnableRainbowSquigglyBrackets = settingsForm?.isRainbowSquigglyBracketsEnabled() ?: true
         settings.isEnableRainbowSquareBrackets = settingsForm?.isRainbowSquareBracketsEnabled() ?: true
+        settings.isEnableHighlightCurrentScopeWhenCtrlPressed = settingsForm?.isHighlightCurrentScopeWhenCtrlPressed() ?: true
         settings.isDoNOTRainbowifyBracketsWithoutContent = settingsForm?.isDoNOTRainbowifyBracketsWithoutContent() ?: false
     }
 

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowSettings.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowSettings.kt
@@ -18,6 +18,7 @@ class RainbowSettings : PersistentStateComponent<RainbowSettings> {
     var isEnableRainbowSquigglyBrackets = true
     var isEnableRainbowSquareBrackets = true
     var isEnableRainbowAngleBrackets = true
+    var isEnableHighlightCurrentScopeWhenCtrlPressed = true
     var isDoNOTRainbowifyBracketsWithoutContent = false
     var version: String? = null
     var isRainbowifyHTMLInsideJS = false

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.form
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.github.izhangzhihao.rainbow.brackets.settings.form.RainbowSettingsForm">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="602" height="400"/>
@@ -8,10 +8,10 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="fd26e" binding="appearancePanel" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="fd26e" binding="appearancePanel" layout-manager="GridLayoutManager" row-count="7" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="etched" title-resource-bundle="plugin" title-key="version"/>
@@ -32,11 +32,6 @@
               <text value="Enable rainbow round brackets"/>
             </properties>
           </component>
-          <hspacer id="49e37">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </hspacer>
           <component id="39590" class="javax.swing.JCheckBox" binding="enableRainbowSquigglyBrackets" default-binding="true">
             <constraints>
               <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -45,11 +40,6 @@
               <text value="Enable rainbow squiggly brackets"/>
             </properties>
           </component>
-          <hspacer id="49e38">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </hspacer>
           <component id="8c5f3" class="javax.swing.JCheckBox" binding="enableRainbowSquareBrackets" default-binding="true">
             <constraints>
               <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -58,11 +48,6 @@
               <text value="Enable rainbow square brackets"/>
             </properties>
           </component>
-          <hspacer id="49e39">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </hspacer>
           <component id="2a235" class="javax.swing.JCheckBox" binding="enableRainbowAngleBrackets" default-binding="true">
             <constraints>
               <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -71,35 +56,29 @@
               <text value="Enable rainbow angle brackets"/>
             </properties>
           </component>
-          <hspacer id="49e40">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </hspacer>
           <component id="51ef4" class="javax.swing.JCheckBox" binding="doNOTRainbowifyBracketsWithoutContent">
+            <constraints>
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Do NOT rainbowify brackets without content"/>
+            </properties>
+          </component>
+          <component id="550d8" class="javax.swing.JCheckBox" binding="enableHighlightCurrentScopeWhenCtrlPressed">
             <constraints>
               <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Do NOT rainbowify brackets without content"/>
+              <text value="Highlight current scope when Ctrl/Meta(Mac) key pressed"/>
             </properties>
           </component>
         </children>
       </grid>
       <vspacer id="9e387">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-      <grid id="7d11d" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <border type="none"/>
-        <children/>
-      </grid>
     </children>
   </grid>
 </form>

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.kt
@@ -11,6 +11,7 @@ class RainbowSettingsForm {
     private var enableRainbowSquigglyBrackets: JCheckBox? = null
     private var enableRainbowSquareBrackets: JCheckBox? = null
     private var enableRainbowAngleBrackets: JCheckBox? = null
+    private var enableHighlightCurrentScopeWhenCtrlPressed: JCheckBox? = null
     private var doNOTRainbowifyBracketsWithoutContent: JCheckBox? = null
 
     private val settings: RainbowSettings = RainbowSettings.instance
@@ -27,6 +28,8 @@ class RainbowSettingsForm {
 
     fun isRainbowAngleBracketsEnabled() = enableRainbowAngleBrackets?.isSelected
 
+    fun isHighlightCurrentScopeWhenCtrlPressed() = enableHighlightCurrentScopeWhenCtrlPressed?.isSelected
+
     fun isDoNOTRainbowifyBracketsWithoutContent() = doNOTRainbowifyBracketsWithoutContent?.isSelected
 
     val isModified: Boolean
@@ -35,6 +38,7 @@ class RainbowSettingsForm {
                 || isRainbowRoundBracketsEnabled() != settings.isEnableRainbowRoundBrackets
                 || isRainbowSquigglyBracketsEnabled() != settings.isEnableRainbowSquigglyBrackets
                 || isRainbowSquareBracketsEnabled() != settings.isEnableRainbowSquareBrackets
+                || isHighlightCurrentScopeWhenCtrlPressed() != settings.isEnableHighlightCurrentScopeWhenCtrlPressed
                 || isDoNOTRainbowifyBracketsWithoutContent() != settings.isDoNOTRainbowifyBracketsWithoutContent)
 
     init {
@@ -47,6 +51,7 @@ class RainbowSettingsForm {
         enableRainbowAngleBrackets?.isSelected = settings.isEnableRainbowAngleBrackets
         enableRainbowSquigglyBrackets?.isSelected = settings.isEnableRainbowSquigglyBrackets
         enableRainbowSquareBrackets?.isSelected = settings.isEnableRainbowSquareBrackets
+        enableHighlightCurrentScopeWhenCtrlPressed?.isSelected = settings.isEnableHighlightCurrentScopeWhenCtrlPressed
         doNOTRainbowifyBracketsWithoutContent?.isSelected = settings.isDoNOTRainbowifyBracketsWithoutContent
     }
 }

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/visitor/DefaultRainbowVisitor.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/visitor/DefaultRainbowVisitor.kt
@@ -8,7 +8,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.tree.IElementType
-import org.jetbrains.kotlin.psi.psiUtil.endOffset
 
 /**
  * DefaultRainbowVisitor
@@ -33,9 +32,9 @@ class DefaultRainbowVisitor : RainbowHighlightVisitor() {
 
         val level = element.getBracketLevel(pair)
         if (level >= 0) {
-            val startOffset = if (element.elementType == pair.leftBraceType) element.startOffset else null
-            val endOffset = if (element.elementType == pair.rightBraceType) element.endOffset else null
-            element.setHighlightInfo(element.parent, level, startOffset, endOffset)
+            val startElement = element.takeIf { it.elementType == pair.leftBraceType }
+            val endElement = element.takeIf { it.elementType == pair.rightBraceType }
+            element.setHighlightInfo(element.parent, level, startElement, endElement)
         }
     }
 

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/visitor/DefaultRainbowVisitor.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/visitor/DefaultRainbowVisitor.kt
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.tree.IElementType
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
 
 /**
  * DefaultRainbowVisitor
@@ -32,7 +33,9 @@ class DefaultRainbowVisitor : RainbowHighlightVisitor() {
 
         val level = element.getBracketLevel(pair)
         if (level >= 0) {
-            element.setHighlightInfo(level)
+            val startOffset = if (element.elementType == pair.leftBraceType) element.startOffset else null
+            val endOffset = if (element.elementType == pair.rightBraceType) element.endOffset else null
+            element.setHighlightInfo(element.parent, level, startOffset, endOffset)
         }
     }
 

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/visitor/RainbowHighlightVisitor.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/visitor/RainbowHighlightVisitor.kt
@@ -51,25 +51,31 @@ abstract class RainbowHighlightVisitor : HighlightVisitor {
         check(isCalled) { "Overriding method must invoke super." }
     }
 
-    protected fun PsiElement.setHighlightInfo(parent: PsiElement?, level: Int, startOffset: Int?, endOffset: Int?) {
+    protected fun PsiElement.setHighlightInfo(parent: PsiElement?,
+                                              level: Int,
+                                              startElement: PsiElement?,
+                                              endElement: PsiElement?) {
         getHighlightInfo(this, level)
                 ?.also {
                     highlightInfoHolder?.add(it)
 
-                    if (startOffset != null || endOffset != null) {
+                    if (startElement != null || endElement != null) {
                         val color = it.forcedTextAttributes.foregroundColor
-                        parent?.saveRainbowInfo(level, color, startOffset, endOffset)
+                        parent?.saveRainbowInfo(level, color, startElement, endElement)
                     }
                 }
     }
 
-    private fun PsiElement.saveRainbowInfo(level: Int, color: Color, startOffset: Int?, endOffset: Int?) {
+    private fun PsiElement.saveRainbowInfo(level: Int,
+                                           color: Color,
+                                           startElement: PsiElement?,
+                                           endElement: PsiElement?) {
         val rainbowInfo = RainbowInfo.KEY_RAINBOW[this]?.also {
             it.level = level
             it.color = color
         } ?: RainbowInfo(level, color).also { RainbowInfo.KEY_RAINBOW[this] = it }
 
-        startOffset?.let { rainbowInfo.startOffset = it }
-        endOffset?.let { rainbowInfo.endOffset = it }
+        startElement?.let { rainbowInfo.startElement = it }
+        endElement?.let { rainbowInfo.endElement = it }
     }
 }

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/visitor/XmlRainbowVisitor.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/visitor/XmlRainbowVisitor.kt
@@ -8,8 +8,6 @@ import com.intellij.psi.xml.XmlFile
 import com.intellij.psi.xml.XmlTag
 import com.intellij.psi.xml.XmlToken
 import com.intellij.psi.xml.XmlTokenType
-import org.jetbrains.kotlin.psi.psiUtil.endOffset
-import org.jetbrains.kotlin.psi.psiUtil.startOffset
 
 /**
  * XmlRainbowVisitor
@@ -36,46 +34,31 @@ open class XmlRainbowVisitor : RainbowHighlightVisitor() {
             XmlTokenType.XML_DOCTYPE_END,
             XmlTokenType.XML_PI_START,
             XmlTokenType.XML_PI_END -> {
-                val startOffset = when (tokenType) {
-                    XmlTokenType.XML_DOCTYPE_START,
-                    XmlTokenType.XML_PI_START -> element.startOffset
-                    else -> null
+                val startElement = element.takeIf {
+                    tokenType == XmlTokenType.XML_DOCTYPE_START || tokenType == XmlTokenType.XML_PI_START
                 }
-                val endOffset = when (tokenType) {
-                    XmlTokenType.XML_DOCTYPE_END,
-                    XmlTokenType.XML_PI_END -> element.endOffset
-                    else -> null
+                val endElement = element.takeIf {
+                    tokenType == XmlTokenType.XML_DOCTYPE_END || tokenType == XmlTokenType.XML_PI_END
                 }
-                element.setHighlightInfo(element.xmlParent, 0, startOffset, endOffset)
+                element.setHighlightInfo(element.xmlParent, 0, startElement, endElement)
             }
 
             XmlTokenType.XML_START_TAG_START,
             XmlTokenType.XML_END_TAG_START,
             XmlTokenType.XML_TAG_END,
             XmlTokenType.XML_EMPTY_ELEMENT_END -> {
-                val startOffset = when (tokenType) {
-                    XmlTokenType.XML_START_TAG_START -> element.startOffset
-                    else -> null
+                val startElement = element.takeIf { tokenType == XmlTokenType.XML_START_TAG_START }
+                val endElement = element.takeIf {
+                    tokenType == XmlTokenType.XML_TAG_END || tokenType == XmlTokenType.XML_EMPTY_ELEMENT_END
                 }
-                val endOffset = when (tokenType) {
-                    XmlTokenType.XML_TAG_END,
-                    XmlTokenType.XML_EMPTY_ELEMENT_END -> element.endOffset
-                    else -> null
-                }
-                element.level?.let { element.setHighlightInfo(element.xmlParent, it, startOffset, endOffset) }
+                element.level?.let { element.setHighlightInfo(element.xmlParent, it, startElement, endElement) }
             }
 
             XmlTokenType.XML_CDATA_START,
             XmlTokenType.XML_CDATA_END -> {
-                val startOffset = when (tokenType) {
-                    XmlTokenType.XML_CDATA_START -> element.startOffset
-                    else -> null
-                }
-                val endOffset = when (tokenType) {
-                    XmlTokenType.XML_CDATA_END -> element.endOffset
-                    else -> null
-                }
-                element.level?.let { element.setHighlightInfo(element.parent, it + 1, startOffset, endOffset) }
+                val startElement = element.takeIf { tokenType == XmlTokenType.XML_CDATA_START }
+                val endElement = element.takeIf { tokenType == XmlTokenType.XML_CDATA_END }
+                element.level?.let { element.setHighlightInfo(element.parent, it + 1, startElement, endElement) }
             }
         }
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -216,6 +216,8 @@
         <applicationConfigurable instance="com.github.izhangzhihao.rainbow.brackets.settings.RainbowConfigurable"/>
         <applicationService serviceInterface="com.github.izhangzhihao.rainbow.brackets.settings.RainbowSettings"
                             serviceImplementation="com.github.izhangzhihao.rainbow.brackets.settings.RainbowSettings"/>
+        <applicationService serviceInterface="com.github.izhangzhihao.rainbow.brackets.EditorEventActionManager"
+                            serviceImplementation="com.github.izhangzhihao.rainbow.brackets.EditorEventActionManager"/>
     </extensions>
 
     <application-components>


### PR DESCRIPTION
Feature #37:
![1](https://user-images.githubusercontent.com/10737066/39988979-5df3f05e-579b-11e8-8d19-7d9e95c7a0b5.gif)

目前的实现方式是在按下Ctrl（Mac是Meta）键时高亮，这样的话在使用带Ctrl键的快捷键时也会触发高亮，这有一定的影响，但先这样吧，可以先看看反馈如何，实在不行的话再想办法使用快捷键的方式实现。