### PR TITLE
Rainbow indent guides

### DIFF
--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/action/AbstractScopeHighlightingAction.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/action/AbstractScopeHighlightingAction.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import java.awt.Color
 import java.awt.event.FocusEvent
 import java.awt.event.FocusListener
 import java.awt.event.KeyAdapter
@@ -92,16 +91,6 @@ abstract class AbstractScopeHighlightingAction : AnAction() {
             }
 
             return null
-        }
-
-        fun Color.alphaBlend(background: Color, alpha: Float): Color {
-            require(alpha in 0.0..1.0) { "alpha(0.0 <= alpha <= 1.0): $alpha" }
-
-            val r = (1 - alpha) * background.red + alpha * red
-            val g = (1 - alpha) * background.green + alpha * green
-            val b = (1 - alpha) * background.blue + alpha * blue
-
-            return Color(r.toInt(), g.toInt(), b.toInt())
         }
     }
 }

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/action/ScopeHighlightingAction.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/action/ScopeHighlightingAction.kt
@@ -2,6 +2,7 @@ package com.github.izhangzhihao.rainbow.brackets.action
 
 import com.github.izhangzhihao.rainbow.brackets.RainbowInfo
 import com.github.izhangzhihao.rainbow.brackets.settings.RainbowSettings
+import com.github.izhangzhihao.rainbow.brackets.util.alphaBlend
 import com.intellij.codeInsight.highlighting.HighlightManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.EditorColorsManager

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/action/ScopeOutsideHighlightingRestrainAction.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/action/ScopeOutsideHighlightingRestrainAction.kt
@@ -2,6 +2,7 @@ package com.github.izhangzhihao.rainbow.brackets.action
 
 import com.github.izhangzhihao.rainbow.brackets.RainbowInfo
 import com.github.izhangzhihao.rainbow.brackets.settings.RainbowSettings
+import com.github.izhangzhihao.rainbow.brackets.util.alphaBlend
 import com.intellij.codeInsight.highlighting.HighlightManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.EditorColorsManager

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPass.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPass.kt
@@ -29,7 +29,6 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.psi.xml.XmlElement
 import com.intellij.psi.xml.XmlFile
 import com.intellij.psi.xml.XmlTag
 import com.intellij.util.DocumentUtil
@@ -476,7 +475,7 @@ class RainbowIndentsPass internal constructor(
             var element = psiFile.findElementAt(highlighter.endOffset)?.parent ?: return null
 
             var rainbowInfo = RainbowInfo.RAINBOW_INFO_KEY[element]
-            if (rainbowInfo == null && psiFile is XmlFile && element is XmlElement && element !is XmlTag) {
+            if (rainbowInfo == null && psiFile is XmlFile && element !is XmlTag) {
                 element = PsiTreeUtil.findFirstParent(element, true, XML_TAG_PARENT_CONDITION) ?: return null
                 rainbowInfo = RainbowInfo.RAINBOW_INFO_KEY[element] ?: return null
             }

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPass.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPass.kt
@@ -1,0 +1,452 @@
+package com.github.izhangzhihao.rainbow.brackets.indents
+
+import com.intellij.codeHighlighting.TextEditorHighlightingPass
+import com.intellij.codeInsight.highlighting.BraceMatchingUtil
+import com.intellij.lang.Language
+import com.intellij.lang.LanguageParserDefinitions
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.IndentGuideDescriptor
+import com.intellij.openapi.editor.VisualPosition
+import com.intellij.openapi.editor.colors.EditorColors
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.editor.ex.util.EditorUtil
+import com.intellij.openapi.editor.markup.CustomHighlighterRenderer
+import com.intellij.openapi.editor.markup.HighlighterTargetArea
+import com.intellij.openapi.editor.markup.MarkupModel
+import com.intellij.openapi.editor.markup.RangeHighlighter
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.Segment
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+import com.intellij.psi.tree.TokenSet
+import com.intellij.util.DocumentUtil
+import com.intellij.util.containers.IntStack
+import com.intellij.util.text.CharArrayUtil
+import java.awt.Color
+import java.lang.StrictMath.*
+import java.util.*
+
+// From com.intellij.codeInsight.daemon.impl.IndentsPass
+class RainbowIndentsPass internal constructor(
+        project: Project,
+        editor: Editor,
+        private val myFile: PsiFile
+) : TextEditorHighlightingPass(project, editor.document, false), DumbAware {
+
+    private val myEditor: EditorEx = editor as EditorEx
+
+    @Volatile
+    private var myRanges = emptyList<TextRange>()
+
+    @Volatile
+    private var myDescriptors = emptyList<IndentGuideDescriptor>()
+
+    override fun doCollectInformation(progress: ProgressIndicator) {
+        val document = checkNotNull(myDocument)
+        val stamp = myEditor.getUserData(LAST_TIME_INDENTS_BUILT)
+        if (stamp != null && stamp.toLong() == nowStamp()) return
+
+        myDescriptors = buildDescriptors()
+
+        val ranges = ArrayList<TextRange>()
+        for (descriptor in myDescriptors) {
+            ProgressManager.checkCanceled()
+            val endOffset = if (descriptor.endLine < document.lineCount) {
+                document.getLineStartOffset(descriptor.endLine)
+            } else {
+                document.textLength
+            }
+            ranges.add(TextRange(document.getLineStartOffset(descriptor.startLine), endOffset))
+        }
+
+        Collections.sort(ranges, Segment.BY_START_OFFSET_THEN_END_OFFSET)
+        myRanges = ranges
+    }
+
+    private fun nowStamp(): Long {
+        return if (myEditor.settings.isIndentGuidesShown) {
+            checkNotNull(myDocument).modificationStamp
+        } else -1
+    }
+
+    override fun doApplyInformationToEditor() {
+        val stamp = myEditor.getUserData(LAST_TIME_INDENTS_BUILT)
+        if (stamp != null && stamp.toLong() == nowStamp()) return
+
+        val oldHighlighters = myEditor.getUserData(INDENT_HIGHLIGHTERS_IN_EDITOR_KEY)
+        val newHighlighters = ArrayList<RangeHighlighter>()
+        val mm = myEditor.markupModel
+
+        var curRange = 0
+
+        if (oldHighlighters != null) {
+            // after document change some range highlighters could have become invalid, or the order could have been broken
+            oldHighlighters.sortWith(Comparator.comparing { h: RangeHighlighter -> !h.isValid }
+                    .thenComparing(Segment.BY_START_OFFSET_THEN_END_OFFSET))
+
+            var curHighlight = 0
+            while (curRange < myRanges.size && curHighlight < oldHighlighters.size) {
+                val range = myRanges[curRange]
+                val highlighter = oldHighlighters[curHighlight]
+                if (!highlighter.isValid) break
+
+                val cmp = compare(range, highlighter)
+                when {
+                    cmp < 0 -> {
+                        newHighlighters.add(createHighlighter(mm, range))
+                        curRange++
+                    }
+                    cmp > 0 -> {
+                        highlighter.dispose()
+                        curHighlight++
+                    }
+                    else -> {
+                        newHighlighters.add(highlighter)
+                        curHighlight++
+                        curRange++
+                    }
+                }
+            }
+
+            while (curHighlight < oldHighlighters.size) {
+                val highlighter = oldHighlighters[curHighlight]
+                if (!highlighter.isValid) break
+                highlighter.dispose()
+                curHighlight++
+            }
+        }
+
+        val startRangeIndex = curRange
+        val document = checkNotNull(myDocument)
+        DocumentUtil.executeInBulk(document, myRanges.size > 10000) {
+            for (i in startRangeIndex until myRanges.size) {
+                newHighlighters.add(createHighlighter(mm, myRanges[i]))
+            }
+        }
+
+
+        myEditor.putUserData(INDENT_HIGHLIGHTERS_IN_EDITOR_KEY, newHighlighters)
+        myEditor.putUserData(LAST_TIME_INDENTS_BUILT, nowStamp())
+        myEditor.indentsModel.assumeIndents(myDescriptors)
+    }
+
+    private fun buildDescriptors(): List<IndentGuideDescriptor> {
+        if (!myEditor.settings.isIndentGuidesShown) return emptyList()
+
+        val calculator = IndentsCalculator()
+        calculator.calculate()
+        val lineIndents = calculator.lineIndents
+
+        val lines = IntStack()
+        val indents = IntStack()
+
+        lines.push(0)
+        indents.push(0)
+        val descriptors = ArrayList<IndentGuideDescriptor>()
+        for (line in 1 until lineIndents.size) {
+            ProgressManager.checkCanceled()
+            val curIndent = abs(lineIndents[line])
+
+            while (!indents.empty() && curIndent <= indents.peek()) {
+                ProgressManager.checkCanceled()
+                val level = indents.pop()
+                val startLine = lines.pop()
+                if (level > 0) {
+                    for (i in startLine until line) {
+                        if (level != abs(lineIndents[i])) {
+                            descriptors.add(createDescriptor(level, startLine, line, lineIndents))
+                            break
+                        }
+                    }
+                }
+            }
+
+            val prevLine = line - 1
+            val prevIndent = abs(lineIndents[prevLine])
+
+            if (curIndent - prevIndent > 1) {
+                lines.push(prevLine)
+                indents.push(prevIndent)
+            }
+        }
+
+        val document = checkNotNull(myDocument)
+        while (!indents.empty()) {
+            ProgressManager.checkCanceled()
+            val level = indents.pop()
+            val startLine = lines.pop()
+            if (level > 0) {
+                descriptors.add(createDescriptor(level, startLine, document.lineCount, lineIndents))
+            }
+        }
+        return descriptors
+    }
+
+    private fun createDescriptor(
+            level: Int,
+            startLine: Int,
+            endLine: Int,
+            lineIndents: IntArray
+    ): IndentGuideDescriptor {
+        var sLine = startLine
+        while (sLine > 0 && lineIndents[sLine] < 0) sLine--
+        // int codeConstructStartLine = findCodeConstructStartLine(startLine);
+        return IndentGuideDescriptor(level, sLine, endLine)
+    }
+
+    /*
+    private fun findCodeConstructStartLine(startLine: Int): Int {
+        val document = myEditor.document
+        val text = document.immutableCharSequence
+        val lineStartOffset = document.getLineStartOffset(startLine)
+        val firstNonWsOffset = CharArrayUtil.shiftForward(text, lineStartOffset, " \t")
+        val type = PsiUtilBase.getPsiFileAtOffset(myFile, firstNonWsOffset).fileType
+        val language = PsiUtilCore.getLanguageAtOffset(myFile, firstNonWsOffset)
+        val braceMatcher = BraceMatchingUtil.getBraceMatcher(type, language)
+        val iterator = myEditor.highlighter.createIterator(firstNonWsOffset)
+        return if (braceMatcher.isLBraceToken(iterator, text, type)) {
+            val codeConstructStart = braceMatcher.getCodeConstructStart(myFile, firstNonWsOffset)
+            document.getLineNumber(codeConstructStart)
+        } else {
+            startLine
+        }
+    }
+    */
+
+    private inner class IndentsCalculator internal constructor() {
+        internal val myComments: MutableMap<Language, TokenSet> = HashMap()
+        internal val lineIndents: IntArray // negative value means the line is empty (or contains a comment) and indent
+        // (denoted by absolute value) was deduced from enclosing non-empty lines
+        internal val myChars: CharSequence
+
+        init {
+            val document = checkNotNull(myDocument)
+            lineIndents = IntArray(document.lineCount)
+            myChars = document.charsSequence
+        }
+
+        /**
+         * Calculates line indents for the [target document][.myDocument].
+         */
+        internal fun calculate() {
+            val document = checkNotNull(myDocument)
+            val fileType = myFile.fileType
+            val tabSize = EditorUtil.getTabSize(myEditor)
+
+            for (line in lineIndents.indices) {
+                ProgressManager.checkCanceled()
+                val lineStart = document.getLineStartOffset(line)
+                val lineEnd = document.getLineEndOffset(line)
+                var offset = lineStart
+                var column = 0
+                outer@ while (offset < lineEnd) {
+                    when (myChars[offset]) {
+                        ' ' -> column++
+                        '\t' -> column = (column / tabSize + 1) * tabSize
+                        else -> break@outer
+                    }
+                    offset++
+                }
+                // treating commented lines in the same way as empty lines
+                // Blank line marker
+                lineIndents[line] = if (offset == lineEnd || isComment(offset)) -1 else column
+            }
+
+            var topIndent = 0
+            var line = 0
+            while (line < lineIndents.size) {
+                ProgressManager.checkCanceled()
+                if (lineIndents[line] >= 0) {
+                    topIndent = lineIndents[line]
+                } else {
+                    val startLine = line
+                    while (line < lineIndents.size && lineIndents[line] < 0) {
+                        line++
+                    }
+
+                    val bottomIndent = if (line < lineIndents.size) lineIndents[line] else topIndent
+
+                    var indent = min(topIndent, bottomIndent)
+                    if (bottomIndent < topIndent) {
+                        val lineStart = document.getLineStartOffset(line)
+                        val lineEnd = document.getLineEndOffset(line)
+                        val nonWhitespaceOffset = CharArrayUtil.shiftForward(myChars, lineStart, lineEnd, " \t")
+                        val iterator = myEditor.highlighter.createIterator(nonWhitespaceOffset)
+                        if (BraceMatchingUtil.isRBraceToken(iterator, myChars, fileType)) {
+                            indent = topIndent
+                        }
+                    }
+
+                    for (blankLine in startLine until line) {
+                        assert(lineIndents[blankLine] == -1)
+                        lineIndents[blankLine] = -min(topIndent, indent)
+                    }
+
+
+                    line-- // will be incremented back at the end of the loop;
+                }
+                line++
+            }
+        }
+
+        private fun isComment(offset: Int): Boolean {
+            val it = myEditor.highlighter.createIterator(offset)
+            val tokenType = it.tokenType
+            val language = tokenType.language
+            var comments: TokenSet? = myComments[language]
+            if (comments == null) {
+                val definition = LanguageParserDefinitions.INSTANCE.forLanguage(language)
+                if (definition != null) {
+                    comments = definition.commentTokens
+                }
+                if (comments == null) {
+                    return false
+                } else {
+                    myComments[language] = comments
+                }
+            }
+            return comments.contains(tokenType)
+        }
+    }
+
+    companion object {
+        private val INDENT_HIGHLIGHTERS_IN_EDITOR_KEY = Key.create<MutableList<RangeHighlighter>>("_INDENT_HIGHLIGHTERS_IN_EDITOR_KEY_")
+        private val LAST_TIME_INDENTS_BUILT = Key.create<Long>("_LAST_TIME_INDENTS_BUILT_")
+
+        private val RENDERER: CustomHighlighterRenderer = CustomHighlighterRenderer { editor, highlighter, g ->
+            val startOffset = highlighter.startOffset
+            val doc = highlighter.document
+            if (startOffset >= doc.textLength) return@CustomHighlighterRenderer
+
+            val endOffset = highlighter.endOffset
+            val endLine = doc.getLineNumber(endOffset)
+
+            var off: Int
+            var startLine = doc.getLineNumber(startOffset)
+            val descriptor = editor.indentsModel.getDescriptor(startLine, endLine)
+
+            val chars = doc.charsSequence
+            do {
+                val start = doc.getLineStartOffset(startLine)
+                val end = doc.getLineEndOffset(startLine)
+                off = CharArrayUtil.shiftForward(chars, start, end, " \t")
+                startLine--
+            } while (startLine > 1 && off < doc.textLength && chars[off] == '\n')
+
+            val startPosition = editor.offsetToVisualPosition(off)
+            var indentColumn = startPosition.column
+
+            // It's considered that indent guide can cross not only white space but comments, javadoc etc. Hence, there is a possible
+            // case that the first indent guide line is, say, single-line comment where comment symbols ('//') are located at the first
+            // visual column. We need to calculate correct indent guide column then.
+            var lineShift = 1
+            if (indentColumn <= 0 && descriptor != null) {
+                indentColumn = descriptor.indentLevel
+                lineShift = 0
+            }
+            if (indentColumn <= 0) return@CustomHighlighterRenderer
+
+            val foldingModel = editor.foldingModel
+            if (foldingModel.isOffsetCollapsed(off)) return@CustomHighlighterRenderer
+
+            val headerRegion = foldingModel.getCollapsedRegionAtOffset(doc.getLineEndOffset(doc.getLineNumber(off)))
+            val tailRegion = foldingModel.getCollapsedRegionAtOffset(doc.getLineStartOffset(doc.getLineNumber(endOffset)))
+
+            if (tailRegion != null && tailRegion === headerRegion) return@CustomHighlighterRenderer
+
+            val selected: Boolean
+            val guide = editor.indentsModel.caretIndentGuide
+            selected = if (guide != null) {
+                val caretModel = editor.caretModel
+                val caretOffset = caretModel.offset
+                caretOffset in off until endOffset && caretModel.logicalPosition.column == indentColumn
+            } else false
+
+            val start = editor.visualPositionToXY(VisualPosition(startPosition.line + lineShift, indentColumn))
+            val endPosition = editor.offsetToVisualPosition(endOffset)
+            val end = editor.visualPositionToXY(VisualPosition(endPosition.line, endPosition.column))
+            var maxY = end.y
+            if (endPosition.line == editor.offsetToVisualPosition(doc.textLength).line) {
+                maxY += editor.lineHeight
+            }
+
+            val clip = g.clipBounds
+            if (clip != null) {
+                if (clip.y >= maxY || clip.y + clip.height <= start.y) {
+                    return@CustomHighlighterRenderer
+                }
+                maxY = min(maxY, clip.y + clip.height)
+            }
+
+            val scheme = editor.colorsScheme
+            g.color = scheme.getColor(if (selected) EditorColors.SELECTED_INDENT_GUIDE_COLOR else EditorColors.INDENT_GUIDE_COLOR)
+
+            // There is a possible case that indent line intersects soft wrap-introduced text. Example:
+            //     this is a long line <soft-wrap>
+            // that| is soft-wrapped
+            //     |
+            //     | <- vertical indent
+            //
+            // Also it's possible that no additional intersections are added because of soft wrap:
+            //     this is a long line <soft-wrap>
+            //     |   that is soft-wrapped
+            //     |
+            //     | <- vertical indent
+            // We want to use the following approach then:
+            //     1. Show only active indent if it crosses soft wrap-introduced text;
+            //     2. Show indent as is if it doesn't intersect with soft wrap-introduced text;
+            if (selected) {
+                g.color = Color.RED
+                g.drawLine(start.x + 2, start.y, start.x + 2, maxY - 1)
+            } else {
+                var y = start.y
+                var newY = start.y
+                val softWrapModel = editor.softWrapModel
+                val lineHeight = editor.lineHeight
+                var i = max(0, startLine + lineShift)
+                while (i < endLine && newY < maxY) {
+                    val softWraps = softWrapModel.getSoftWrapsForLine(i)
+                    var logicalLineHeight = softWraps.size * lineHeight
+                    if (i > startLine + lineShift) {
+                        logicalLineHeight += lineHeight // We assume that initial 'y' value points just below the target line.
+                    }
+                    if (softWraps.isNotEmpty() && softWraps[0].indentInColumns < indentColumn) {
+                        if (y < newY || i > startLine + lineShift) { // There is a possible case that soft wrap is located on indent start line.
+                            g.drawLine(start.x + 2, y, start.x + 2, newY + lineHeight - 1)
+                        }
+                        newY += logicalLineHeight
+                        y = newY
+                    } else {
+                        newY += logicalLineHeight
+                    }
+
+                    val foldRegion = foldingModel.getCollapsedRegionAtOffset(doc.getLineEndOffset(i))
+                    if (foldRegion != null && foldRegion.endOffset < doc.textLength) {
+                        i = doc.getLineNumber(foldRegion.endOffset)
+                    }
+                    i++
+                }
+
+                if (y < maxY) {
+                    g.color = Color.GREEN
+                    g.drawLine(start.x + 2, y, start.x + 2, maxY - 1)
+                }
+            }
+        }
+
+        private fun createHighlighter(mm: MarkupModel, range: TextRange): RangeHighlighter {
+            val highlighter = mm.addRangeHighlighter(range.startOffset, range.endOffset, 0, null, HighlighterTargetArea.EXACT_RANGE)
+            highlighter.customRenderer = RENDERER
+            return highlighter
+        }
+
+        private fun compare(r: TextRange, h: RangeHighlighter): Int {
+            val answer = r.startOffset - h.startOffset
+            return if (answer != 0) answer else r.endOffset - h.endOffset
+        }
+    }
+}

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPass.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPass.kt
@@ -2,6 +2,7 @@ package com.github.izhangzhihao.rainbow.brackets.indents
 
 import com.github.izhangzhihao.rainbow.brackets.RainbowInfo
 import com.github.izhangzhihao.rainbow.brackets.settings.RainbowSettings
+import com.github.izhangzhihao.rainbow.brackets.util.alphaBlend
 import com.intellij.codeHighlighting.TextEditorHighlightingPass
 import com.intellij.codeInsight.highlighting.BraceMatchingUtil
 import com.intellij.lang.Language
@@ -410,7 +411,12 @@ class RainbowIndentsPass internal constructor(
                 maxY = min(maxY, clip.y + clip.height)
             }
 
-            g.color = if (selected) rainbowInfo.color else rainbowInfo.color
+            g.color = if (selected) {
+                rainbowInfo.color
+            } else {
+                val defaultBackground = editor.colorsScheme.defaultBackground
+                rainbowInfo.color.alphaBlend(defaultBackground, 0.2f)
+            }
 
             // There is a possible case that indent line intersects soft wrap-introduced text. Example:
             //     this is a long line <soft-wrap>

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPass.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPass.kt
@@ -75,12 +75,7 @@ class RainbowIndentsPass internal constructor(
         myRanges = ranges
     }
 
-    private fun nowStamp(): Long {
-        val settings = RainbowSettings.instance
-        return if (settings.isRainbowEnabled && settings.isShowRainbowIndentGuides) {
-            checkNotNull(myDocument).modificationStamp
-        } else -1
-    }
+    private fun nowStamp(): Long = if (isRainbowIndentGuidesShown()) checkNotNull(myDocument).modificationStamp else -1
 
     override fun doApplyInformationToEditor() {
         val stamp = myEditor.getUserData(LAST_TIME_INDENTS_BUILT)
@@ -155,7 +150,7 @@ class RainbowIndentsPass internal constructor(
     }
 
     private fun buildDescriptors(): List<IndentGuideDescriptor> {
-        if (!myEditor.settings.isIndentGuidesShown) return emptyList()
+        if (!isRainbowIndentGuidesShown()) return emptyList()
 
         val calculator = IndentsCalculator()
         calculator.calculate()
@@ -485,6 +480,11 @@ class RainbowIndentsPass internal constructor(
             }
 
             return rainbowInfo
+        }
+
+        private fun isRainbowIndentGuidesShown(): Boolean {
+            val settings = RainbowSettings.instance
+            return settings.isRainbowEnabled && settings.isShowRainbowIndentGuides
         }
 
         private fun createHighlighter(mm: MarkupModel, range: TextRange): RangeHighlighter {

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPass.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPass.kt
@@ -482,10 +482,8 @@ class RainbowIndentsPass internal constructor(
             return rainbowInfo
         }
 
-        private fun isRainbowIndentGuidesShown(): Boolean {
-            val settings = RainbowSettings.instance
-            return settings.isRainbowEnabled && settings.isShowRainbowIndentGuides
-        }
+        private fun isRainbowIndentGuidesShown(): Boolean =
+                RainbowSettings.instance.isRainbowEnabled && RainbowSettings.instance.isShowRainbowIndentGuides
 
         private fun createHighlighter(mm: MarkupModel, range: TextRange): RangeHighlighter {
             return mm.addRangeHighlighter(

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPass.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPass.kt
@@ -29,6 +29,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.xml.XmlElement
 import com.intellij.psi.xml.XmlFile
 import com.intellij.psi.xml.XmlTag
 import com.intellij.util.DocumentUtil
@@ -474,15 +475,17 @@ class RainbowIndentsPass internal constructor(
             val psiFile = PsiManager.getInstance(project).findFile(editor.virtualFile) ?: return null
             var element = psiFile.findElementAt(highlighter.endOffset)?.parent ?: return null
 
-            if (psiFile is XmlFile && element !is XmlTag) {
+            var rainbowInfo = RainbowInfo.RAINBOW_INFO_KEY[element]
+            if (rainbowInfo == null && psiFile is XmlFile && element is XmlElement && element !is XmlTag) {
                 element = PsiTreeUtil.findFirstParent(element, true, XML_TAG_PARENT_CONDITION) ?: return null
+                rainbowInfo = RainbowInfo.RAINBOW_INFO_KEY[element] ?: return null
             }
 
             if (document.getLineNumber(element.startOffset) < document.getLineNumber(highlighter.startOffset)) {
                 return null
             }
 
-            return RainbowInfo.RAINBOW_INFO_KEY[element]
+            return rainbowInfo
         }
 
         private fun createHighlighter(mm: MarkupModel, range: TextRange): RangeHighlighter {

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPassFactory.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPassFactory.kt
@@ -13,7 +13,13 @@ class RainbowIndentsPassFactory(project: Project, registrar: TextEditorHighlight
         AbstractProjectComponent(project), TextEditorHighlightingPassFactory {
 
     init {
-        registrar.registerTextEditorHighlightingPass(this, TextEditorHighlightingPassRegistrar.Anchor.BEFORE, Pass.UPDATE_FOLDING, false, false)
+        registrar.registerTextEditorHighlightingPass(
+                this,
+                TextEditorHighlightingPassRegistrar.Anchor.LAST,
+                Pass.LAST_PASS,
+                false,
+                false
+        )
     }
 
     override fun getComponentName(): String = "RainbowIndentsPassFactory"

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPassFactory.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/indents/RainbowIndentsPassFactory.kt
@@ -1,0 +1,24 @@
+package com.github.izhangzhihao.rainbow.brackets.indents
+
+import com.intellij.codeHighlighting.Pass
+import com.intellij.codeHighlighting.TextEditorHighlightingPass
+import com.intellij.codeHighlighting.TextEditorHighlightingPassFactory
+import com.intellij.codeHighlighting.TextEditorHighlightingPassRegistrar
+import com.intellij.openapi.components.AbstractProjectComponent
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+
+class RainbowIndentsPassFactory(project: Project, registrar: TextEditorHighlightingPassRegistrar) :
+        AbstractProjectComponent(project), TextEditorHighlightingPassFactory {
+
+    init {
+        registrar.registerTextEditorHighlightingPass(this, TextEditorHighlightingPassRegistrar.Anchor.BEFORE, Pass.UPDATE_FOLDING, false, false)
+    }
+
+    override fun getComponentName(): String = "RainbowIndentsPassFactory"
+
+    override fun createHighlightingPass(file: PsiFile, editor: Editor): TextEditorHighlightingPass {
+        return RainbowIndentsPass(myProject, editor, file)
+    }
+}

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowConfigurable.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowConfigurable.kt
@@ -26,6 +26,7 @@ class RainbowConfigurable : Configurable {
         settings.isEnableRainbowAngleBrackets = settingsForm?.isRainbowAngleBracketsEnabled() ?: true
         settings.isEnableRainbowSquigglyBrackets = settingsForm?.isRainbowSquigglyBracketsEnabled() ?: true
         settings.isEnableRainbowSquareBrackets = settingsForm?.isRainbowSquareBracketsEnabled() ?: true
+        settings.isShowRainbowIndentGuides = settingsForm?.isShowRainbowIndentGuides() ?: false
         settings.isDoNOTRainbowifyBracketsWithoutContent = settingsForm?.isDoNOTRainbowifyBracketsWithoutContent()
                 ?: false
         settings.isDoNOTRainbowifyTheFirstLevel = settingsForm?.isDoNOTRainbowifyTheFirstLevel() ?: false

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowSettings.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowSettings.kt
@@ -18,6 +18,7 @@ class RainbowSettings : PersistentStateComponent<RainbowSettings> {
     var isEnableRainbowSquigglyBrackets = true
     var isEnableRainbowSquareBrackets = true
     var isEnableRainbowAngleBrackets = true
+    var isShowRainbowIndentGuides = false
     var isDoNOTRainbowifyBracketsWithoutContent = false
     var isDoNOTRainbowifyTheFirstLevel = false
     var version = "Unknown"

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.form
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.form
@@ -8,7 +8,7 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="fd26e" binding="appearancePanel" layout-manager="GridLayoutManager" row-count="8" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="fd26e" binding="appearancePanel" layout-manager="GridLayoutManager" row-count="9" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -58,7 +58,7 @@
           </component>
           <component id="51ef4" class="javax.swing.JCheckBox" binding="doNOTRainbowifyBracketsWithoutContent">
             <constraints>
-              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Do NOT rainbowify brackets without content"/>
@@ -66,7 +66,7 @@
           </component>
           <component id="c0e39" class="javax.swing.JCheckBox" binding="isDoNOTRainbowifyTheFirstLevel">
             <constraints>
-              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Do NOT rainbowify the first level"/>
@@ -74,10 +74,18 @@
           </component>
           <component id="65411" class="javax.swing.JCheckBox" binding="pressAnyKeyToRemoveTheHighlightingEffects">
             <constraints>
-              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Press any key to remove the highlighting effects(Using ESC to remove effects by default)"/>
+            </properties>
+          </component>
+          <component id="8753" class="javax.swing.JCheckBox" binding="showRainbowIndentGuides">
+            <constraints>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Show rainbow indent guides (Experimental)"/>
             </properties>
           </component>
         </children>

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.kt
@@ -13,6 +13,7 @@ class RainbowSettingsForm {
     private var enableRainbowSquigglyBrackets: JCheckBox? = null
     private var enableRainbowSquareBrackets: JCheckBox? = null
     private var enableRainbowAngleBrackets: JCheckBox? = null
+    private var showRainbowIndentGuides: JCheckBox? = null
     private var doNOTRainbowifyBracketsWithoutContent: JCheckBox? = null
     private var isDoNOTRainbowifyTheFirstLevel: JCheckBox? = null
     private var pressAnyKeyToRemoveTheHighlightingEffects: JCheckBox? = null
@@ -31,6 +32,8 @@ class RainbowSettingsForm {
 
     fun isRainbowAngleBracketsEnabled() = enableRainbowAngleBrackets?.isSelected
 
+    fun isShowRainbowIndentGuides() = showRainbowIndentGuides?.isSelected
+
     fun isDoNOTRainbowifyBracketsWithoutContent() = doNOTRainbowifyBracketsWithoutContent?.isSelected
 
     fun isDoNOTRainbowifyTheFirstLevel() = isDoNOTRainbowifyTheFirstLevel?.isSelected
@@ -43,6 +46,7 @@ class RainbowSettingsForm {
                 || isRainbowRoundBracketsEnabled() != settings.isEnableRainbowRoundBrackets
                 || isRainbowSquigglyBracketsEnabled() != settings.isEnableRainbowSquigglyBrackets
                 || isRainbowSquareBracketsEnabled() != settings.isEnableRainbowSquareBrackets
+                || isShowRainbowIndentGuides() != settings.isShowRainbowIndentGuides
                 || isDoNOTRainbowifyBracketsWithoutContent() != settings.isDoNOTRainbowifyBracketsWithoutContent
                 || isDoNOTRainbowifyTheFirstLevel() != settings.isDoNOTRainbowifyTheFirstLevel
                 || pressAnyKeyToRemoveTheHighlightingEffects() != settings.pressAnyKeyToRemoveTheHighlightingEffects
@@ -58,6 +62,7 @@ class RainbowSettingsForm {
         enableRainbowAngleBrackets?.isSelected = settings.isEnableRainbowAngleBrackets
         enableRainbowSquigglyBrackets?.isSelected = settings.isEnableRainbowSquigglyBrackets
         enableRainbowSquareBrackets?.isSelected = settings.isEnableRainbowSquareBrackets
+        showRainbowIndentGuides?.isSelected = settings.isShowRainbowIndentGuides
         doNOTRainbowifyBracketsWithoutContent?.isSelected = settings.isDoNOTRainbowifyBracketsWithoutContent
         isDoNOTRainbowifyTheFirstLevel?.isSelected = settings.isDoNOTRainbowifyTheFirstLevel
         pressAnyKeyToRemoveTheHighlightingEffects?.isSelected = settings.pressAnyKeyToRemoveTheHighlightingEffects

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/util/Colors.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/util/Colors.kt
@@ -1,0 +1,14 @@
+package com.github.izhangzhihao.rainbow.brackets.util
+
+import java.awt.Color
+
+
+fun Color.alphaBlend(background: Color, alpha: Float): Color {
+    require(alpha in 0.0..1.0) { "alpha(0.0 <= alpha <= 1.0): $alpha" }
+
+    val r = (1 - alpha) * background.red + alpha * red
+    val g = (1 - alpha) * background.green + alpha * green
+    val b = (1 - alpha) * background.blue + alpha * blue
+
+    return Color(r.toInt(), g.toInt(), b.toInt())
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -404,6 +404,11 @@
     </application-components>
 
     <project-components>
+        <component>
+            <implementation-class>com.github.izhangzhihao.rainbow.brackets.indents.RainbowIndentsPassFactory
+            </implementation-class>
+            <skipForDefaultProject/>
+        </component>
     </project-components>
 
     <actions>

--- a/src/test/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowConfigurableTest.kt
+++ b/src/test/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowConfigurableTest.kt
@@ -29,6 +29,7 @@ class RainbowConfigurableTest : LightCodeInsightFixtureTestCase() {
         rainbowConfigurable.settingsForm!!.isRainbowRoundBracketsEnabled() shouldBe true
         rainbowConfigurable.settingsForm!!.isRainbowSquareBracketsEnabled() shouldBe true
         rainbowConfigurable.settingsForm!!.isRainbowSquigglyBracketsEnabled() shouldBe true
+        rainbowConfigurable.settingsForm!!.isShowRainbowIndentGuides() shouldBe false
         rainbowConfigurable.settingsForm!!.isDoNOTRainbowifyBracketsWithoutContent() shouldBe false
 
         rainbowConfigurable.disposeUIResources()


### PR DESCRIPTION
**Feature:** #164 

**已知问题：**
1. 缩进线绘制的代码超过95%都是来源于IDE内部的代码，因此绘制行为IDE内部的基本是一致的。而其实现的主要依据并不是代码块，而是缩进字符。所以在缩进没有对齐的情况下会带来一些问题，虽然对于IDE内部的缩进线来说，这个问题并不算什么问题，但对插件来说就是大问题了： **缩进线的颜色与括号的颜色会不相同！** 因此，我只好关掉了这部分缩进线的绘制：
  ![image](https://user-images.githubusercontent.com/10737066/65811911-5ec7d300-e1f2-11e9-831e-e836a85aff2a.png)
  ![image](https://user-images.githubusercontent.com/10737066/65811954-e3b2ec80-e1f2-11e9-9ff9-76e2efb0ed44.png)
2. 对 **`Language injection`** 部分的代码缩进没有作用:
  ![image](https://user-images.githubusercontent.com/10737066/65812037-2cb77080-e1f4-11e9-8f91-6138794cc993.png)
