### PR TITLE
Update RainbowSettingsForm.form

### DIFF
--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.form
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.form
@@ -77,7 +77,7 @@
               <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Press any key to remove the highlighting effects(Using ESC to remove effects by default)"/>
+              <text value="Press any key to remove the highlighting effects (use ESC to remove effects by default)"/>
             </properties>
           </component>
           <component id="8753" class="javax.swing.JCheckBox" binding="showRainbowIndentGuides">


### PR DESCRIPTION
In settings text add space before "(" and fix the sequence of tenses