### PR TITLE
Remove "233" tooltip from "Apply colors of round for all brackets" checkbox in settings

### DIFF
--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.form
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.form
@@ -95,7 +95,6 @@
             <properties>
               <selected value="false"/>
               <text value="Apply colors of round for all brackets"/>
-              <toolTipText value="233"/>
             </properties>
           </component>
           <component id="9d54" class="javax.swing.JLabel">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/277842/89272615-51f7e500-d636-11ea-9c79-36ea57494768.png)
