### PR TITLE
Add configurable threshold for number of lines for big files

### DIFF
--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/RainbowifyBanner.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/RainbowifyBanner.kt
@@ -42,15 +42,15 @@ class RainbowifyBanner : EditorNotifications.Provider<EditorNotificationPanel>()
         if (psiFile != null && !checkForBigFile(psiFile)) {
             if (RainbowSettings.instance.suppressBigFileCheck) return null
             return EditorNotificationPanel().apply {
-                text("Rainbowify is disabled for files > 1000 lines by default")
+                text("Rainbowify is disabled for files > " + RainbowSettings.instance.bigFilesLinesThreshold + " lines")
                 icon(AllIcons.General.InspectionsEye)
                 createComponentActionLabel("got it, don't show again") {
                     RainbowSettings.instance.suppressBigFileCheck = true
                     EditorNotifications.getInstance(project).updateAllNotifications()
                 }
 
-                createComponentActionLabel("enable rainbowify for big files") {
-                    RainbowSettings.instance.doNOTRainbowifyBigFiles = false
+                createComponentActionLabel("open settings") {
+                    ShowSettingsUtilImpl.showSettingsDialog(project, RainbowConfigurable.ID, "")
                     EditorNotifications.getInstance(project).updateAllNotifications()
                 }
             }

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowConfigurable.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowConfigurable.kt
@@ -43,6 +43,7 @@ class RainbowConfigurable : SearchableConfigurable {
         settings.rainbowifyTagNameInXML = settingsForm?.rainbowifyTagNameInXML() ?: false
         settings.doNOTRainbowifyTemplateString = settingsForm?.doNOTRainbowifyTemplateString() ?: false
         settings.doNOTRainbowifyBigFiles = settingsForm?.doNOTRainbowifyBigFiles() ?: true
+        settings.bigFilesLinesThreshold = settingsForm?.bigFilesLinesThreshold() ?: 1000
         settings.rainbowifyPythonKeywords = settingsForm?.rainbowifyPythonKeywords() ?: false
     }
 

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowSettings.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/RainbowSettings.kt
@@ -40,6 +40,7 @@ class RainbowSettings : PersistentStateComponent<RainbowSettings> {
     var rainbowifyTagNameInXML = false
     var doNOTRainbowifyTemplateString = false
     var doNOTRainbowifyBigFiles = true
+    var bigFilesLinesThreshold = 1000
 
     var languageBlacklist: Set<String> = setOf("hocon", "mxml")
 

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.form
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.form
@@ -158,14 +158,45 @@
               <text value="Do NOT rainbowify template string"/>
             </properties>
           </component>
-          <component id="454cb" class="javax.swing.JCheckBox" binding="doNOTRainbowifyBigFiles">
+          <grid id="528ba" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <border type="none"/>
             <constraints>
               <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
-            <properties>
-              <text value="Do NOT rainbowify big files"/>
-            </properties>
-          </component>
+            <properties/>
+            <children>
+              <component id="454cb" class="javax.swing.JCheckBox" binding="doNOTRainbowifyBigFiles">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Do NOT rainbowify files with more than"/>
+                </properties>
+              </component>
+              <component id="ac934" class="javax.swing.JTextField" binding="bigFilesLinesThreshold">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <name value=""/>
+                  <text value="1000"/>
+                </properties>
+              </component>
+              <component id="92b4" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                    <preferred-size width="96" height="14"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <text value="lines"/>
+                </properties>
+              </component>
+            </children>
+          </grid>
           <component id="6e2da" class="javax.swing.JLabel">
             <constraints>
               <grid row="18" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/settings/form/RainbowSettingsForm.kt
@@ -35,6 +35,8 @@ class RainbowSettingsForm {
 
     private var doNOTRainbowifyBigFiles: JCheckBox? = null
 
+    private var bigFilesLinesThreshold: JTextField? = null
+
     private var rainbowifyPythonKeywords: JCheckBox? = null
 
     private val settings: RainbowSettings = RainbowSettings.instance
@@ -78,6 +80,8 @@ class RainbowSettingsForm {
 
     fun doNOTRainbowifyBigFiles() = doNOTRainbowifyBigFiles?.isSelected
 
+    fun bigFilesLinesThreshold() = bigFilesLinesThreshold?.text?.toIntOrNull()
+
     fun rainbowifyPythonKeywords() = rainbowifyPythonKeywords?.isSelected
 
     val isModified: Boolean
@@ -98,12 +102,14 @@ class RainbowSettingsForm {
                 || rainbowifyTagNameInXML() != settings.rainbowifyTagNameInXML
                 || doNOTRainbowifyTemplateString() != settings.doNOTRainbowifyTemplateString
                 || doNOTRainbowifyBigFiles() != settings.doNOTRainbowifyBigFiles
+                || bigFilesLinesThreshold() != settings.bigFilesLinesThreshold
                 || languageBlacklist() != settings.languageBlacklist
                 || rainbowifyPythonKeywords() != settings.rainbowifyPythonKeywords
                 )
 
     init {
         loadSettings()
+        doNOTRainbowifyBigFiles?.addActionListener({e -> bigFilesLinesThreshold?.setEnabled(doNOTRainbowifyBigFiles() ?: false)})
     }
 
     fun loadSettings() {
@@ -124,6 +130,7 @@ class RainbowSettingsForm {
         rainbowifyTagNameInXML?.isSelected = settings.rainbowifyTagNameInXML
         doNOTRainbowifyTemplateString?.isSelected = settings.doNOTRainbowifyTemplateString
         doNOTRainbowifyBigFiles?.isSelected = settings.doNOTRainbowifyBigFiles
+        bigFilesLinesThreshold?.text = settings.bigFilesLinesThreshold.toString()
         languageBlacklist?.text = settings.languageBlacklist.joinToString(",")
         rainbowifyPythonKeywords?.isSelected = settings.rainbowifyPythonKeywords
     }

--- a/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/visitor/RainbowHighlightVisitor.kt
+++ b/src/main/kotlin/com/github/izhangzhihao/rainbow/brackets/visitor/RainbowHighlightVisitor.kt
@@ -86,7 +86,8 @@ abstract class RainbowHighlightVisitor : HighlightVisitor {
         }
 
         fun checkForBigFile(file: PsiFile): Boolean =
-                !(RainbowSettings.instance.doNOTRainbowifyBigFiles && file.getLineCount() > 1000)
+                !(RainbowSettings.instance.doNOTRainbowifyBigFiles &&
+                        file.getLineCount() > RainbowSettings.instance.bigFilesLinesThreshold)
 
         private fun fileIsNotHaskellOrIntelliJHaskellPluginNotEnabled(fileType: String) =
                 fileType != "Haskell" || !isIntelliJHaskellEnabled


### PR DESCRIPTION
Follow-up of https://github.com/izhangzhihao/intellij-rainbow-brackets/issues/784#issuecomment-1158778294.

This PR adds a text field to the checkbox for "do NOT rainbowify big files", to configure the maximum number of lines for which the plugin will work, if this checkbox is enabled. I've also updated the notification that pops up if a file is larger than that: instead of an "enable rainbowify for big files" button, it's now an "open settings" button, because the user may want to either disable the setting or increase the threshold.

Small implementation note: I'm not sure how the `id`s for the form components are generated, so I typed some random hexadecimal values and hope that's fine :slightly_smiling_face: 